### PR TITLE
refactor: replace github.com/pkg/errors with stdlib errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/fearful-symmetry/gorapl
 
 go 1.16
 
-require (
-	github.com/fearful-symmetry/gomsr v0.0.1
-	github.com/pkg/errors v0.9.1
-)
+require github.com/fearful-symmetry/gomsr v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
 github.com/fearful-symmetry/gomsr v0.0.1 h1:m208RzdTApWVbv8a9kf78rdPLQe+BY9AxRb/nSbHxSA=
 github.com/fearful-symmetry/gomsr v0.0.1/go.mod h1:Qb/0Y7zwobP7v8Sji+M5mlL4N7Voyz5WaKXXRFPnLio=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/rapl/rapl.go
+++ b/rapl/rapl.go
@@ -1,9 +1,8 @@
 package rapl
 
 import (
+	"errors"
 	"fmt"
-
-	"github.com/pkg/errors"
 
 	"github.com/fearful-symmetry/gomsr"
 )
@@ -27,12 +26,12 @@ func CreateNewHandler(cpu int, fmtS string) (RAPLHandler, error) {
 	if fmtS == "" {
 		msr, err = gomsr.MSR(cpu)
 		if err != nil {
-			return RAPLHandler{}, errors.Wrap(err, "error creating MSR handler")
+			return RAPLHandler{}, fmt.Errorf("error creating MSR handler: %w", err)
 		}
 	} else {
 		msr, err = gomsr.MSRWithLocation(cpu, fmtS)
 		if err != nil {
-			return RAPLHandler{}, errors.Wrapf(err, "error creating MSR handler with location %s", fmtS)
+			return RAPLHandler{}, fmt.Errorf("error creating MSR handler with location %s: %w", fmtS, err)
 		}
 	}
 
@@ -45,7 +44,7 @@ func CreateNewHandler(cpu int, fmtS string) (RAPLHandler, error) {
 
 	handler.units, err = handler.ReadPowerUnit()
 	if err != nil {
-		return RAPLHandler{}, errors.Wrapf(err, "error reading power units")
+		return RAPLHandler{}, fmt.Errorf("error reading power units: %w", err)
 	}
 
 	return handler, nil


### PR DESCRIPTION
Go 1.13 added improved error handling. fmt.Errorf can be used to replace error wrapping and drop the github.com/pkg/errors dependency.

This library is used in https://github.com/elastic/beats so this is just to streamline the dependency graph